### PR TITLE
Fix typos, schedule bug and pomodoro test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# �� td (To-Do ToDay)
+# td (To-Do ToDay)
 
 ![td logo](td-logo.svg)
 
@@ -18,7 +18,7 @@ stores your progress in easy-to-read markdown files.
 
 ### Prerequisites
 
-- Go 1.16 or higher
+- Go 1.23 or higher
 
 ### Installation
 

--- a/cmd/day.go
+++ b/cmd/day.go
@@ -328,6 +328,6 @@ func notifyDayStart(shutdownTimeMinutes int) {
 
 func scheduleNotification(t time.Time, content string) {
 	datetime := t.Format("2006-01-02 15:04")
-	cmd := exec.Command("systemd-run", "--user", "--on-calendar", datetime, "notify-send", content)
+	cmd := exec.Command("systemd-run", "--user", "--on-calendar="+datetime, "notify-send", content)
 	_ = cmd.Run() // ignore errors for now
 }

--- a/cmd/pomo_test.go
+++ b/cmd/pomo_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"os"
 	"testing"
+	"time"
+
+	"github.com/Jakub3628800/td/core"
 )
 
 func TestPomoIntegration(t *testing.T) {
@@ -22,8 +26,24 @@ func TestRootCommandPomoKey(t *testing.T) {
 }
 
 func TestRecordPomoSession(t *testing.T) {
-	// Skip this test as it requires user interaction
-	t.Skip("Skipping integration test that requires user interaction")
+	dir := t.TempDir()
+	os.Setenv("TD_VAULT_LOC", dir)
+	os.Setenv("TD_INTERVAL_MODE", "daily")
+	core.ResetForTest(dir, "daily")
 
-	// The test body is skipped completely
+	now := time.Now()
+	duration := 5
+	recordPomoSession(duration, "completed")
+
+	log, err := core.LoadDayLog(now)
+	if err != nil {
+		t.Fatalf("LoadDayLog failed: %v", err)
+	}
+	if len(log.Pomodoros) == 0 {
+		t.Fatal("no pomodoro sessions recorded")
+	}
+	p := log.Pomodoros[0]
+	if p.Duration != duration || p.Status != "completed" {
+		t.Errorf("unexpected pomodoro entry: %+v", p)
+	}
 }


### PR DESCRIPTION
## Summary
- fix garbled README title and update Go version requirement
- pass schedule time correctly to `systemd-run`
- implement `TestRecordPomoSession`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f50cc66f4832088207539fd257dc0